### PR TITLE
Add Weekly Exploration playlist support

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 import yaml
-from modules.listenbrainz_functions import get_weeklyjams_playlist
+from modules.listenbrainz_functions import get_weeklyjams_playlist,get_weeklyexploration_playlist
 from modules.plex_functions import set_section
 
 with open("config.yml", 'r') as ymlfile:
@@ -8,3 +8,4 @@ with open("config.yml", 'r') as ymlfile:
 if __name__ == "__main__":
     set_section()
     get_weeklyjams_playlist(cfg['user_token'])
+    get_weeklyexploration_playlist(cfg['user_token'])

--- a/modules/listenbrainz_functions.py
+++ b/modules/listenbrainz_functions.py
@@ -13,9 +13,6 @@ with open("config.yml", 'r') as ymlfile:
 
 track_list = []
 
-search_title = get_playlist_title(cfg['playlist_username'])
-
-
 def get_weeklyjams_playlist(user_token):
     """
     Goes through all the 'Created For' playlists and returns the 'Weekly Jams' playlist for the current week
@@ -24,6 +21,39 @@ def get_weeklyjams_playlist(user_token):
     """
     username = cfg['playlist_username']
 
+    search_title = get_playlist_title(username)
+
+    try:
+        get_playlist(username,user_token,search_title)
+    except Exception as e:
+        logger.error(f"Unable to create Weekly Exploration playlist")
+
+
+def get_weeklyexploration_playlist(user_token):
+    """
+    Goes through all the 'Created For' playlists and returns the 'Weekly Exploration' playlist for the current week
+    :param user_token: The ListenBrainz token for the user
+    :return: The 'Weekly Exploration' playlist info
+    """
+    username = cfg['playlist_username']
+
+    search_title = get_playlist_exploration_title(username)
+
+    try:
+        get_playlist(username,user_token,search_title)
+    except Exception as e:
+        logger.error(f"Unable to create Weekly Exploration playlist")
+
+
+
+def get_playlist(username, user_token, search_title):
+    """
+    Goes through all the 'Created For' playlists and returns the 'Weekly Exploration' playlist for the current week
+    :param username: The ListenBrainz username for the user
+    :param user_token: The ListenBrainz token for the user
+    :param search_title: Search string for the playlist title
+    :return: The 'Weekly Exploration' playlist info
+    """
     try:
         logger.info("Getting playlists...")
 
@@ -49,7 +79,7 @@ def get_weeklyjams_playlist(user_token):
 
             # Find the playlist that is titled search_title
             for playlist in playlists:
-                if playlist['playlist']['title'] == search_title:
+                if search_title in playlist['playlist']['title']:
                     playlist_mbid = playlist['playlist']['identifier'].split('/')[-1]
 
                     # Get the name of the second playlist
@@ -74,7 +104,6 @@ def get_weeklyjams_playlist(user_token):
     except Exception as e:
         logger.error(f"An error occurred: {e}")
         exit()
-
 
 def get_tracks_from_playlist(user_token, playlist_mbid):
     """

--- a/modules/misc_utils.py
+++ b/modules/misc_utils.py
@@ -19,10 +19,31 @@ def get_playlist_title(username: str):
     # Format the date as 'YYYY-MM-DD'
     formatted_date = most_recent_monday.strftime('%Y-%m-%d')
 
-    title = f"Weekly Jams for {username}, week of {formatted_date} Mon"
+    title = f"Weekly Jams for {username}"
 
     return title
 
+def get_playlist_exploration_title(username: str):
+    """
+    Gets the date of the most recent Monday and formats it for the title to search for
+    :param username: The username for the playlist
+    :return: The formatted title to search for
+    """
+    # Get the current date
+    current_date = datetime.now()
+
+    # Calculate the difference in days between the current day and Monday (weekday 0)
+    days_to_monday = (current_date.weekday() - 0) % 7
+
+    # Subtract the difference to get the date of the most recent Monday
+    most_recent_monday = current_date - timedelta(days=days_to_monday)
+
+    # Format the date as 'YYYY-MM-DD'
+    formatted_date = most_recent_monday.strftime('%Y-%m-%d')
+
+    title = f"Weekly Exploration for {username}"
+
+    return title
 
 def normalize_characters(title: str):
     """


### PR DESCRIPTION
- Move logic from `get_weeklyjams_playlist()` into new generic `get_playlist()` 
- Extend `get_playlist()` to now take a `search_title` 
- Change filter to now use a `in` rather than an explicit match
- Add `get_playlist_exploration_title()` to get search string for weekly exploration playlist title 
- Add `get_weeklyexploration_playlist()` to `main.py`.

Closes #3

TODO: add cfg option for enabling each playlist type.