### PR TITLE
Added playlist_prefix param to change Plex playlist names

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ auto-generated one from Plex. This upload only happens during initial creation o
 
 `filter_genre` is also optional. This field is used to filter out unwanted tracks by genre. A use case could be removing pesky Christmas songs infiltrating your playlist in the off-season.
 
+`playlist_prefix` is optional. Playlists are "Weekly Jams" and "Daily Jams". If you want to put something in front to make them "A_Weekly Jams" or whatever, put it here. Leave it blank (two quotes '' ) to not use a prefix.
+
 A completed Plex section looks like this:
 
 ```
@@ -36,6 +38,7 @@ token: 'abcdef123456789'
 music_section: 'Music' 
 poster_file_path: 'path\to\poster.png'
 filter_genre: 'Christmas'
+playlist_prefix: ''
 ```
 
 #### ListenBrainz

--- a/config.yml.example
+++ b/config.yml.example
@@ -4,6 +4,7 @@ token: 'YOUR_TOKEN' # Replace 'YOUR_USER_TOKEN' with your Plex token
 music_section: 'YOUR_SECTION_NAME' # Replace 'YOUR_SECTION_NAME' with the name of your music section
 poster_file_path: 'YOUR_FILE_PATH' # OPTIONAL, replace 'YOUR_FILE_PATH' with the filepath to a poster for the playlist
 filter_genre: 'YOUR_GENRE' # OPTIONAL, replace 'YOUR_GENRE' with the genre you want to filter by (case-sensitive, one only).
+playlist_prefix: 'A_' # playlists are "Weekly Jams" and "Daily Jams". If you want to put something in front to make them "A_Weekly Jams" or whatever, put it here. Leave it blank (two quotes '' ) to not use a prefix
 
 # ListenBrainz Info
 user_token: 'YOUR_USER_TOKEN' # Replace 'YOUR_USER_TOKEN' with your actual ListenBrainz user token

--- a/main.py
+++ b/main.py
@@ -1,12 +1,19 @@
 import yaml
 from modules.listenbrainz_functions import get_weeklyjams_playlist,get_weeklyexploration_playlist,get_dailyjams_playlist
 from modules.plex_functions import set_section
+from datetime import date
+import calendar
 
 with open("config.yml", 'r') as ymlfile:
     cfg = yaml.safe_load(ymlfile)
 
 if __name__ == "__main__":
+    my_date = date.today()
+    today = calendar.day_name[my_date.weekday()]
+    print(today)
+
     set_section()
     get_dailyjams_playlist(cfg['user_token'])
-    get_weeklyjams_playlist(cfg['user_token'])
+    if today == "Monday":
+      get_weeklyjams_playlist(cfg['user_token'])
     #get_weeklyexploration_playlist(cfg['user_token'])

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ with open("config.yml", 'r') as ymlfile:
 if __name__ == "__main__":
     my_date = date.today()
     today = calendar.day_name[my_date.weekday()]
-    print(today)
+    logger.info("today is "+today)
 
     set_section()
     get_dailyjams_playlist(cfg['user_token'])

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 import yaml
-from modules.listenbrainz_functions import get_weeklyjams_playlist,get_weeklyexploration_playlist
+from modules.listenbrainz_functions import get_weeklyjams_playlist,get_weeklyexploration_playlist,get_dailyjams_playlist
 from modules.plex_functions import set_section
 
 with open("config.yml", 'r') as ymlfile:
@@ -7,5 +7,6 @@ with open("config.yml", 'r') as ymlfile:
 
 if __name__ == "__main__":
     set_section()
-    get_weeklyjams_playlist(cfg['user_token'])
+    #get_dailyjams_playlist(cfg['user_token'])
+    #get_weeklyjams_playlist(cfg['user_token'])
     get_weeklyexploration_playlist(cfg['user_token'])

--- a/main.py
+++ b/main.py
@@ -4,6 +4,9 @@ from modules.plex_functions import set_section
 from datetime import date
 import calendar
 
+from modules.logger_utils import logger
+
+
 with open("config.yml", 'r') as ymlfile:
     cfg = yaml.safe_load(ymlfile)
 

--- a/main.py
+++ b/main.py
@@ -7,6 +7,6 @@ with open("config.yml", 'r') as ymlfile:
 
 if __name__ == "__main__":
     set_section()
-    #get_dailyjams_playlist(cfg['user_token'])
-    #get_weeklyjams_playlist(cfg['user_token'])
-    get_weeklyexploration_playlist(cfg['user_token'])
+    get_dailyjams_playlist(cfg['user_token'])
+    get_weeklyjams_playlist(cfg['user_token'])
+    #get_weeklyexploration_playlist(cfg['user_token'])

--- a/main.py
+++ b/main.py
@@ -1,17 +1,11 @@
 import yaml
-from modules.listenbrainz_functions import get_playlists
+from modules.listenbrainz_functions import get_weeklyjams_playlist,get_weeklyexploration_playlist
 from modules.plex_functions import set_section
-import logging
 
 with open("config.yml", 'r') as ymlfile:
     cfg = yaml.safe_load(ymlfile)
 
-logging.getLogger("urllib3").setLevel(logging.WARNING)
-logging.getLogger("requests").setLevel(logging.WARNING)
-logging.getLogger("musicbrainzngs").setLevel(logging.WARNING)
-logging.getLogger("plexapi").setLevel(logging.WARNING)
-
-
 if __name__ == "__main__":
     set_section()
-    get_playlists(cfg['user_token'])
+    get_weeklyjams_playlist(cfg['user_token'])
+    get_weeklyexploration_playlist(cfg['user_token'])

--- a/modules/global_variables.py
+++ b/modules/global_variables.py
@@ -6,7 +6,6 @@ mbid: str
 
 playlist_name: str
 playlist_summary: str
-playlist_prefix: str
 
 
 

--- a/modules/global_variables.py
+++ b/modules/global_variables.py
@@ -6,6 +6,7 @@ mbid: str
 
 playlist_name: str
 playlist_summary: str
+playlist_prefix: str
 
 
 

--- a/modules/listenbrainz_functions.py
+++ b/modules/listenbrainz_functions.py
@@ -23,6 +23,7 @@ def get_dailyjams_playlist(user_token):
 
     search_title = get_playlist_daily_title(username)
     logger.info(search_title)
+    logger.info("---------------------------"+search_title)
 
     try:
         get_playlist(username,user_token,search_title)
@@ -39,6 +40,7 @@ def get_weeklyjams_playlist(user_token):
 
     search_title = get_playlist_title(username)
     logger.info(search_title)
+    logger.info("---------------------------"+search_title)
 
     try:
         get_playlist(username,user_token,search_title)
@@ -55,6 +57,7 @@ def get_weeklyexploration_playlist(user_token):
     username = cfg['playlist_username']
 
     search_title = get_playlist_exploration_title(username)
+    logger.info(search_title)
     logger.info("---------------------------"+search_title)
 
     try:

--- a/modules/listenbrainz_functions.py
+++ b/modules/listenbrainz_functions.py
@@ -13,6 +13,22 @@ with open("config.yml", 'r') as ymlfile:
 
 track_list = []
 
+def get_dailyjams_playlist(user_token):
+    """
+    Goes through all the 'Created For' playlists and returns the 'Weekly Jams' playlist for the current week
+    :param user_token: The ListenBrainz token for the user
+    :return: The 'Weekly Jams' playlist info
+    """
+    username = cfg['playlist_username']
+
+    search_title = get_playlist_daily_title(username)
+    logger.info(search_title)
+
+    try:
+        get_playlist(username,user_token,search_title)
+    except Exception as e:
+        logger.error(f"Unable to create Weekly Exploration playlist")
+
 def get_weeklyjams_playlist(user_token):
     """
     Goes through all the 'Created For' playlists and returns the 'Weekly Jams' playlist for the current week
@@ -22,6 +38,7 @@ def get_weeklyjams_playlist(user_token):
     username = cfg['playlist_username']
 
     search_title = get_playlist_title(username)
+    logger.info(search_title)
 
     try:
         get_playlist(username,user_token,search_title)
@@ -38,6 +55,7 @@ def get_weeklyexploration_playlist(user_token):
     username = cfg['playlist_username']
 
     search_title = get_playlist_exploration_title(username)
+    logger.info("---------------------------"+search_title)
 
     try:
         get_playlist(username,user_token,search_title)

--- a/modules/logger_utils.py
+++ b/modules/logger_utils.py
@@ -36,4 +36,4 @@ logger = create_logger()
 
 def get_tqdm_bar(iterable, desc="Processing", unit="item"):
     return tqdm(iterable, desc="\x1b[32m{}:".format(desc), unit=unit,
-                bar_format="\x1b[32m{desc} {percentage:3.0f}%|\x1b[32m{bar}| {n}/{total} tracks processed \x1b[0m")
+                bar_format="\x1b[32m{desc} {percentage:3.0f}%|\x1b[32m{bar}| {n}/{total} tracks found \x1b[0m")

--- a/modules/logger_utils.py
+++ b/modules/logger_utils.py
@@ -20,7 +20,8 @@ def create_logger():
     handler.setFormatter(formatter)
 
     # Set the level for the root logger
-    logging.root.setLevel(logging.NOTSET)
+    #logging.root.setLevel(logging.NOTSET)
+    #logging.root.setLevel(logging.INFO)
 
     # Add the colorlog handler to the root logger
     logging.root.addHandler(handler)

--- a/modules/misc_utils.py
+++ b/modules/misc_utils.py
@@ -1,8 +1,7 @@
 from datetime import datetime, timedelta
-import re
 
 
-def get_weekly_playlist_title(username: str):
+def get_playlist_title(username: str):
     """
     Gets the date of the most recent Monday and formats it for the title to search for
     :param username: The username for the playlist
@@ -20,12 +19,11 @@ def get_weekly_playlist_title(username: str):
     # Format the date as 'YYYY-MM-DD'
     formatted_date = most_recent_monday.strftime('%Y-%m-%d')
 
-    title = f"Weekly Jams for {username}, week of {formatted_date} Mon"
+    title = f"Weekly Jams for {username}"
 
     return title
 
-
-def get_daily_playlist_title(username: str):
+def get_playlist_exploration_title(username: str):
     """
     Gets the date of the most recent Monday and formats it for the title to search for
     :param username: The username for the playlist
@@ -34,16 +32,18 @@ def get_daily_playlist_title(username: str):
     # Get the current date
     current_date = datetime.now()
 
-    # Get the abbreviated weekday name
-    day_abbreviation = current_date.strftime("%a")
+    # Calculate the difference in days between the current day and Monday (weekday 0)
+    days_to_monday = (current_date.weekday() - 0) % 7
+
+    # Subtract the difference to get the date of the most recent Monday
+    most_recent_monday = current_date - timedelta(days=days_to_monday)
 
     # Format the date as 'YYYY-MM-DD'
-    formatted_date = current_date.strftime('%Y-%m-%d')
+    formatted_date = most_recent_monday.strftime('%Y-%m-%d')
 
-    title = f"Daily Jams for {username}, {formatted_date} {day_abbreviation}"
+    title = f"Weekly Exploration for {username}"
 
     return title
-
 
 def normalize_characters(title: str):
     """
@@ -56,23 +56,9 @@ def normalize_characters(title: str):
         '“': '"',
         '”': '"',
         '’': "'",
-        '‐': ' ',
     }
 
     for key, value in char_mapping.items():
         title = title.replace(key, value)
 
     return title
-
-
-# Define a function to check if a string contains Japanese characters
-def contains_japanese(text):
-    # Unicode ranges for Japanese characters
-    # Hiragana: \u3040-\u309F
-    # Katakana: \u30A0-\u30FF
-    # Kanji: \u4E00-\u9FFF
-    # Full-width Katakana: \uFF66-\uFF9D
-    japanese_pattern = re.compile(r'[\u3040-\u30FF\u4E00-\u9FFF\uFF66-\uFF9D]')
-
-    # Search the pattern in the text
-    return bool(japanese_pattern.search(text))

--- a/modules/misc_utils.py
+++ b/modules/misc_utils.py
@@ -1,5 +1,26 @@
 from datetime import datetime, timedelta
 
+def get_playlist_daily_title(username: str):
+    """
+    Gets the date of the most recent Monday and formats it for the title to search for
+    :param username: The username for the playlist
+    :return: The formatted title to search for
+    """
+    # Get the current date
+    current_date = datetime.now()
+
+    # Calculate the difference in days between the current day and Monday (weekday 0)
+    days_to_monday = (current_date.weekday() - 0) % 7
+
+    # Subtract the difference to get the date of the most recent Monday
+    most_recent_monday = current_date - timedelta(days=days_to_monday)
+
+    # Format the date as 'YYYY-MM-DD'
+    formatted_date = most_recent_monday.strftime('%Y-%m-%d')
+
+    title = f"Daily Jams for {username}"
+
+    return title
 
 def get_playlist_title(username: str):
     """

--- a/modules/musicbrainz_functions.py
+++ b/modules/musicbrainz_functions.py
@@ -1,43 +1,40 @@
 import musicbrainzngs
+import logging
 import yaml
-import modules.misc_utils as misc
 
 from modules.logger_utils import logger
 
 with open("config.yml", 'r') as ymlfile:
     cfg = yaml.safe_load(ymlfile)
 
-
 email = cfg['api_email']
 
 # Set your MusicBrainz API key
 musicbrainzngs.set_useragent(app='ListenBrainzToPlex', version='1.0', contact=email)
 
+logging.getLogger("musicbrainzngs").setLevel(logging.WARNING)
 
-# Function to get specific recording MBID and psuedo titles for a recording MBID
-def get_track_mbids(recording_mbid, original_track_title):
+mbids = []
+
+
+# Function to get specific recording MBID for a general recording MBID
+def get_track_mbids(recording_mbid):
+    """
+    Searches and returns all track IDs for a recording
+    :param recording_mbid: The recording ID from Musicbrainz
+    :return: All track IDs associated with a recording
+    """
     try:
-        # Lists to store the MBIDs and titles
-        mbids = []
-        titles = []
-
         # Get information about the general recording using the MBID
         result = musicbrainzngs.search_recordings(rid=recording_mbid)
 
         # Extract specific recording MBID from the result
         for track in result['recording-list'][0]['release-list']:
-            mbid = 'mbid://' + track['medium-list'][0   ]['track-list'][0]['id']
+            mbid = 'mbid://' + track['medium-list'][0]['track-list'][0]['id']
             mbids.append(mbid)
 
-            if misc.contains_japanese(original_track_title):
-                track_title = track['medium-list'][0]['track-list'][0]['title']
-                titles.append(track_title)
-
-        return mbids, titles
+        return mbids
 
     except musicbrainzngs.ResponseError as e:
         logger.error(f"Error: {e}")
         return None
-
-
-

--- a/modules/plex_functions.py
+++ b/modules/plex_functions.py
@@ -148,7 +148,6 @@ def create_playlist():
 
         playlist = g.section.playlist(playlistname)
         #playlist = g.section.playlist(playlist_prefix+g.playlist_name+"_"+today)
-        logger.error(playlist)
         logger.warning("Playlist already exists, checking for new tracks...")
 
         if playlist.items() == plex_tracks:

--- a/modules/plex_functions.py
+++ b/modules/plex_functions.py
@@ -25,9 +25,7 @@ from datetime import date
 import calendar
 my_date = date.today()
 today = calendar.day_name[my_date.weekday()]
-print(today)
-
-
+#print(today)
 
 def set_section():
     """

--- a/modules/plex_functions.py
+++ b/modules/plex_functions.py
@@ -19,6 +19,7 @@ poster_path = cfg['poster_file_path']
 plex_tracks = []  # Found tracks to be added to Plex
 missing_tracks = []  # Any tracks that aren't found in Plex
 
+playlist_prefix = cfg['playlist_prefix']
 
 def set_section():
     """
@@ -142,7 +143,7 @@ def create_playlist():
     logger.info("Checking playlist status...")
     try:
         # Check if the playlist already exists
-        playlist = g.section.playlist(g.playlist_name)
+        playlist = g.section.playlist(playlist_prefix+g.playlist_name)
         logger.warning("Playlist already exists, checking for new tracks...")
 
         if playlist.items() == plex_tracks:
@@ -162,7 +163,7 @@ def create_playlist():
     except plexapi.exceptions.NotFound:
         try:
             logger.info("Playlist not found, creating...")
-            playlist = g.section.createPlaylist(title=g.playlist_name, items=plex_tracks)
+            playlist = g.section.createPlaylist(title=playlist_prefix+g.playlist_name, items=plex_tracks)
             if poster_path != 'YOUR_FILE_PATH':
                 playlist.uploadPoster(filepath=poster_path)
             playlist.edit(summary=g.playlist_summary)

--- a/modules/plex_functions.py
+++ b/modules/plex_functions.py
@@ -108,8 +108,8 @@ def search_for_track(track_list: list[dict]):
 
     logger.info(f"Found a total of {count} tracks")
     logger.warning(f"Missing {len(missing_tracks)} tracks: ")
-    for track in missing_tracks:
-        logger.debug(track['title'])
+    #for track in missing_tracks:
+        #logger.debug(track['title'])
 
     create_playlist()
 

--- a/modules/plex_functions.py
+++ b/modules/plex_functions.py
@@ -21,6 +21,13 @@ missing_tracks = []  # Any tracks that aren't found in Plex
 
 playlist_prefix = cfg['playlist_prefix']
 
+from datetime import date
+import calendar
+my_date = date.today()
+today = calendar.day_name[my_date.weekday()]
+print(today)
+
+
 
 def set_section():
     """
@@ -123,9 +130,25 @@ def create_playlist():
     filter_tracks()
 
     logger.info("Checking playlist status...")
+    logger.warning(g.playlist_name)
+    if g.playlist_name == "Daily Jams":
+      playlistname = playlist_prefix+g.playlist_name+" for "+today
+    else:
+      playlistname = playlist_prefix+g.playlist_name
+    logger.warning(playlistname) 
+    logger.error("==============================================================================================") 
+
+    #exit()
+    #playlist = g.section.createPlaylist(title=playlist_prefix+g.playlist_name, items=plex_tracks)
+
+
     try:
         # Check if the playlist already exists
-        playlist = g.section.playlist(playlist_prefix+g.playlist_name)
+#        playlist = g.section.playlist(playlist_prefix+g.playlist_name+"_"+today)
+
+        playlist = g.section.playlist(playlistname)
+        #playlist = g.section.playlist(playlist_prefix+g.playlist_name+"_"+today)
+        logger.error(playlist)
         logger.warning("Playlist already exists, checking for new tracks...")
 
         if playlist.items() == plex_tracks:
@@ -145,7 +168,8 @@ def create_playlist():
     except plexapi.exceptions.NotFound:
         try:
             logger.info("Playlist not found, creating...")
-            playlist = g.section.createPlaylist(title=playlist_prefix+g.playlist_name, items=plex_tracks)
+            playlist = g.section.createPlaylist(title=playlistname, items=plex_tracks)
+            #playlist = g.section.createPlaylist(title=playlist_prefix+g.playlist_name, items=plex_tracks)
             if poster_path != 'YOUR_FILE_PATH':
                 playlist.uploadPoster(filepath=poster_path)
             playlist.edit(summary=g.playlist_summary)

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd /home/andy/dev/Listenbrainz-Playlist-Sync
+/home/andy/.pyenv/shims/python /home/andy/dev/Listenbrainz-Playlist-Sync/main.py >/tmp/listenbrainz.txt 2>&1


### PR DESCRIPTION
I wanted to be able to easily find my playlists in Plex. The ListenBrainz playlists are called "Weekly Jams" and "Daily Jams". With the playlist_prefix param in config.yml, you can add a string to go in front of the playlist names when they are added to Plex. If playlist_prefix is "A_" then the "Weekly Jams" playlist from ListenBrainz will become "A_Weekly Jams" in Plex. Similarly the "Daily Jams playlist will be "A_Daily Jams".